### PR TITLE
fix(IOSContacts): handle contacts without name

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -147,10 +147,6 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
     
     [output setObject:recordID forKey: @"recordID"];
 
-    if (givenName) {
-        [output setObject: (givenName) ? givenName : @"" forKey:@"givenName"];
-    }
-
     if (familyName) {
         [output setObject: (familyName) ? familyName : @"" forKey:@"familyName"];
     }
@@ -181,6 +177,7 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
     
     //handle phone numbers
     NSMutableArray *phoneNumbers = [[NSMutableArray alloc] init];
+    NSString *firstPhoneNumber = @"";
 
     for (CNLabeledValue<CNPhoneNumber*>* labeledValue in person.phoneNumbers) {
         NSMutableDictionary* phone = [NSMutableDictionary dictionary];
@@ -194,9 +191,14 @@ RCT_EXPORT_METHOD(getAllWithoutPhotos:(RCTResponseSenderBlock) callback)
             [phone setObject: value forKey:@"number"];
             [phone setObject: label forKey:@"label"];
             [phoneNumbers addObject:phone];
+
+            if ([firstPhoneNumber isEqual:@""]) {
+                firstPhoneNumber = value;
+            }
         }
     }
 
+    [output setObject: [givenName isEqualToString:@""] ? firstPhoneNumber : givenName forKey:@"givenName"];
     [output setObject: phoneNumbers forKey:@"phoneNumbers"];
     //end phone numbers
 


### PR DESCRIPTION
# What problem does this PR solve?
On IOS device, contact that saved without name will does not collected by `getAll` method. Android device does it as well

# How does this PR solve it?
- add condition to collect contact without name and map it onto `phoneNumber` instead of null

# Screen shots
- contacts
<img width="371" alt="screen shot 2018-02-19 at 13 04 51" src="https://user-images.githubusercontent.com/29472555/36364260-9ac9d2b8-1575-11e8-9848-13f4980e9c0a.png">


- Get Contacts
<img width="373" alt="screen shot 2018-02-19 at 13 02 42" src="https://user-images.githubusercontent.com/29472555/36364264-9f0429f0-1575-11e8-9cd2-bdea692db7de.png">
