### PR TITLE
Fixing openContactForm modal appearance in iOS 13+

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -612,6 +612,16 @@ RCT_EXPORT_METHOD(openContactForm:(NSDictionary *)contactData callback:(RCTRespo
         UINavigationController* navigation = [[UINavigationController alloc] initWithRootViewController:controller];
         UIViewController *viewController = (UIViewController*)[[[[UIApplication sharedApplication] delegate] window] rootViewController];
         [viewController presentViewController:navigation animated:YES completion:nil];
+        
+        if (@available(iOS 13, *)) {
+            viewController.view.window.backgroundColor=[UIColor blackColor];
+            navigation.navigationBar.topItem.title = @"";
+            UIView *statusBar = [[UIView alloc]initWithFrame:[UIApplication sharedApplication].keyWindow.windowScene.statusBarManager.statusBarFrame];
+            statusBar.backgroundColor = [UIColor blackColor];
+            statusBar.tag=1;
+            controller.navigationController.navigationBar.tintColor = [UIColor blackColor];
+            [[UIApplication sharedApplication].keyWindow addSubview:statusBar];
+        }
 
         updateContactCallback = callback;
     });
@@ -716,6 +726,12 @@ RCT_EXPORT_METHOD(openExistingContact:(NSDictionary *)contactData callback:(RCTR
         }
 
         updateContactCallback = nil;
+    }
+    
+    UIView *statusBar = [[UIApplication sharedApplication].keyWindow viewWithTag:1];
+    
+    if(statusBar) {
+        [statusBar removeFromSuperview];
     }
 }
 


### PR DESCRIPTION
## The problem

When using `openContactForm` modal In iOS 13, the status bar and the background color disappears. Also, the modal navigation title overlaps with the icon showing the picture of initials of a contact. This is caused in part by the latest changes in iOS [Modality](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/modality/) being effective as of iOS 13.

<img width="412" alt="Screenshot 2" src="https://user-images.githubusercontent.com/12549001/66427009-bf1bf900-e9d8-11e9-95cb-c5787104a4d4.png">
<img width="382" alt="Screenshot 4" src="https://user-images.githubusercontent.com/12549001/66427012-bfb48f80-e9d8-11e9-87d7-c25c2712bd79.png">
<img width="412" alt="Screenshot 3" src="https://user-images.githubusercontent.com/12549001/66427013-c04d2600-e9d8-11e9-8309-f10c46ac217a.png">

So, a good solution would be showing the contact form pretty much in fashion of how other apps like Mail does: 

<img width="382" alt="Screenshot 1" src="https://user-images.githubusercontent.com/12549001/66427006-be836280-e9d8-11e9-97dd-ec33d0ebe706.png">

### Changelog

- It hides the title in the navigation bar since it overlaps with the uppercase initials icon.
- Adds status bar view and set it to black color when openContactForm appears.
- Removes status bar from view on Cancel or Done, so it doesn't remain visible when closing the contact form.

### Result

![Screen Shot 2019-10-08 at 13 07 20](https://user-images.githubusercontent.com/12549001/66427943-a6acde00-e9da-11e9-90bd-7d5a0744b071.png)
