### PR TITLE
Allow to delete contact using rawContactId

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -929,24 +929,34 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
     }
 
     /*
-     * Update contact to phone's addressbook
+     * Delete contact from phone's addressbook
      */
     @ReactMethod
     public void deleteContact(ReadableMap contact, Callback callback) {
 
-        String recordID = contact.hasKey("recordID") ? contact.getString("recordID") : null;
-
         try {
-               Context ctx = getReactApplicationContext();
+            String contactId;
+            Uri uri;
 
-               Uri uri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_URI,recordID);
-               ContentResolver cr = ctx.getContentResolver();
-               int deleted = cr.delete(uri,null,null);
+            if (contact.hasKey("recordID")) {
+                contactId = contact.getString("recordID");
+                uri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_URI, contactId);
+            } else if (contact.hasKey("rawContactId")) {
+                contactId = contact.getString("rawContactId");
+                uri = Uri.withAppendedPath(RawContacts.CONTENT_URI, contactId);
+            } else {
+                callback.invoke("Must provide either recordID or rawContactId to deleteContact method", null);
+                return;
+            }
+            Context ctx = getReactApplicationContext();
+            ContentResolver cr = ctx.getContentResolver();
 
-               if(deleted > 0)
-                 callback.invoke(null, recordID); // success
-               else
-                 callback.invoke(null, null); // something was wrong
+            int deleted = cr.delete(uri,null,null);
+
+            if(deleted > 0)
+                callback.invoke(null, contactId); // success
+            else
+                callback.invoke(null, null); // something was wrong
 
         } catch (Exception e) {
             callback.invoke(e.toString(), null);


### PR DESCRIPTION
In some cases, we need to allow deleting contact by `rawContactId`. This PR allows deleting the contact in the old way (providing an object with `recordID`) or by providing the object with `rawContactId`.

`rawContactId` is supported only on Android. 

The real use case:
Our app creates raw contacts using the data from the cloud server. Sometimes Android automatically links it to existing native contacts (created by user in native contacts app). In some circumstances, we need to delete the contacts which were created by our app, but we don't want to affect native contacts that existed before. When we delete using `recordID`, we delete all raw contacts associated with this contact (including both created by our app and by the user in his contacts app). If we support deleting by `rawContactId` we can delete only contact data created by our app and remaining other contact data.

If you'd agree to this change, I will be happy to add a documentation note as well.