### PR TITLE
Exclude example directory from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,10 @@
-examples/
+node_modules
+ios/RCTContacts.xcodeproj/xcuserdata
+ios/RCTContacts.xcodeproj/project.xcworkspace
+
+# Intellij
+.idea
+
+.npm-debug.log
+
+example/


### PR DESCRIPTION
Example directory takes 8.4MB out of total unpacked package size of 8.8 MB. This should greatly reduce the package size.

Results of `yarn pack`:
Before: 7.2M
After: 80K