### PR TITLE
Fix Android StructuredName Update

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -791,7 +791,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
         ArrayList<ContentProviderOperation> ops = new ArrayList<ContentProviderOperation>();
 
         ContentProviderOperation.Builder op = ContentProviderOperation.newUpdate(RawContacts.CONTENT_URI)
-                .withSelection(ContactsContract.Data.CONTACT_ID + "=?", new String[]{String.valueOf(recordID)})
+                .withSelection(ContactsContract.Data.CONTACT_ID + "= ? AND " + ContactsContract.Data.MIMETYPE + " = ?", new String[]{String.valueOf(recordID), StructuredName.CONTENT_ITEM_TYPE})
                 .withValue(RawContacts.ACCOUNT_TYPE, null)
                 .withValue(RawContacts.ACCOUNT_NAME, null);
         ops.add(op.build());


### PR DESCRIPTION
This update operation currently replaces all rows in the `ContactsContract.Data` table for the given `CONTACT_ID` with `StructuredName` data. This replaces all data with mimetype `group_membership`, `note`, `contact_event`, `relation`, `contact_misc` with the contact's `StructuredName`. This PR adds the correct `where` clause to the `StructuredName` update operation so that only rows with `name` mimetype are updated with the `StructuredName` data.