### PR TITLE
Do not update ACCOUNT_TYPE when updating contact

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -790,13 +790,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
 
         ArrayList<ContentProviderOperation> ops = new ArrayList<ContentProviderOperation>();
 
-        ContentProviderOperation.Builder op = ContentProviderOperation.newUpdate(RawContacts.CONTENT_URI)
-                .withSelection(ContactsContract.Data.CONTACT_ID + "= ? AND " + ContactsContract.Data.MIMETYPE + " = ?", new String[]{String.valueOf(recordID), StructuredName.CONTENT_ITEM_TYPE})
-                .withValue(RawContacts.ACCOUNT_TYPE, null)
-                .withValue(RawContacts.ACCOUNT_NAME, null);
-        ops.add(op.build());
-
-        op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
+        ContentProviderOperation.Builder op = ContentProviderOperation.newUpdate(ContactsContract.Data.CONTENT_URI)
                 .withSelection(ContactsContract.Data.CONTACT_ID + "=?", new String[]{String.valueOf(recordID)})
                 .withValue(ContactsContract.Data.MIMETYPE, StructuredName.CONTENT_ITEM_TYPE)
                 .withValue(StructuredName.GIVEN_NAME, givenName)


### PR DESCRIPTION
# Description

On an Android Samsung, S8 and S10 updating the ACCOUNT_TYPE and ACCOUNT_NAME will cause the contact to become un-editable from the native contact app.

Fixes #504

# Affected
Android users on Samsung S8 and S10. Maybe more Samsung models.

# Solution
[Android docs](https://developer.android.com/reference/android/provider/ContactsContract.RawContacts) (See ContactsContract.SyncColumns.ACCOUNT_TYPE) warn against updating the ACCOUNT_NAME and ACCOUNT_TYPE later. Removing that specific update logic to fix the issue.

Not sure if there is a better way. Happy to work with suggestions. 

# Expected change in behavior

None. ACCOUNT_TYPE and ACCOUNT_NAME are not set to null on update.

# How to test

These are my steps to reproduce on S8.

- Create contact using addContact method
- Update that contact's first name and last using updateContact
- Close the React Native application and open the S8 native contact app
- Search for the created contact and click to go to details
- If you tap edit, at the bottom of the page it will crash the native contact app