### PR TITLE
Fixes getContactById crash when contact no longer exists

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -618,7 +618,7 @@ RCT_EXPORT_METHOD(getContactById:(nonnull NSString *)recordID callback:(RCTRespo
     CNContact* contact = [addressBook unifiedContactWithIdentifier:recordID keysToFetch:keysToFetch error:&contactError];
 
     if(!contact)
-            return nil;
+            return [NSNull null];
 
     return [self contactToDictionary: contact withThumbnails:withThumbnails];
 }


### PR DESCRIPTION
Fixes https://github.com/morenoh149/react-native-contacts/pull/430#issuecomment-636049810

Since the calling method is returning an objective-c array in the response callback. by returning nil rather than a [NSNull null], object you are trying to insert nil into an array, which is invalid, and leads to the crash. Its better in the transition between React native and Objective-c to return NSNull objects. This is what the React native side would expect as a response for failure.