### PR TITLE
Fixes crash bug when getting all contacts if defaultContainerIdentifier was null

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -262,11 +262,6 @@ RCT_EXPORT_METHOD(getCount:(RCTResponseSenderBlock) callback)
                            withCallback:(RCTResponseSenderBlock) callback
 {
     NSMutableArray *contacts = [[NSMutableArray alloc] init];
-
-    NSError* contactError;
-    [contactStore containersMatchingPredicate:[CNContainer predicateForContainersWithIdentifiers: @[contactStore.defaultContainerIdentifier]] error:&contactError];
-
-
     NSMutableArray *keysToFetch = [NSMutableArray arrayWithArray: @[
         CNContactEmailAddressesKey,
         CNContactPhoneNumbersKey,


### PR DESCRIPTION
The removed code was never used!

The return value of [contactStore containersMatchingPredicat:] is not used, so the code is redundant. Also we've seen crash reports on this line (when contactStore.defaultContainerIdentifier is nil).