### PR TITLE
Fix CD/CI - Update RCTContacts.m

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -285,6 +285,7 @@ RCT_EXPORT_METHOD(getCount:(RCTResponseSenderBlock) callback)
     }
 
     CNContactFetchRequest * request = [[CNContactFetchRequest alloc]initWithKeysToFetch:keysToFetch];
+    NSError* contactError;
     BOOL success = [contactStore enumerateContactsWithFetchRequest:request error:&contactError usingBlock:^(CNContact * __nonnull contact, BOOL * __nonnull stop){
         NSDictionary *contactDict = [self contactToDictionary: contact withThumbnails:withThumbnails];
         [contacts addObject:contactDict];


### PR DESCRIPTION
Looks like https://github.com/morenoh149/react-native-contacts/commit/a3e64f6b00555e5ca593409e8bb2c871dc6a57e8 accidentally removed `contactError` which is still used.