### PR TITLE
openContactForm typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export function getContactById(contactId: string, callback: (error: any, contact
 export function getCount(callback: (count: number) => void): void;
 export function getPhotoForId(contactId: string, callback: (error: any, photoUri: string) => void): void;
 export function addContact(contact: Contact, callback: (error?: any) => void): void;
-export function openContactForm(contact: Contact, callback: (error: any, contact: Contact) => void): void;
+export function openContactForm(contact: Partial<Contact>, callback: (error: any, contact: Contact) => void): void;
 export function openExistingContact(contact: Contact, callback: (error: any, contact: Contact) => void): void;
 export function editExistingContact(contact: Contact, callback: (error: any, contact: Contact) => void): void;
 export function updateContact(contact: Contact, callback: (error?: any) => void): void;


### PR DESCRIPTION
I'm getting this typescript error
```
src/views/ContactForm/index.tsx:134:30 - error TS2345: Argument of type '{ emailAddresses: { label: string; email: string; }[]; familyName: string; givenName: string; }' is not assignable to parameter of type 'Contact'.
  Type '{ emailAddresses: { label: string; email: string; }[]; familyName: string; givenName: string; }' is missing the following properties from type 'Contact': recordID, backTitle, company, middleName, and 11 more.

134     Contacts.openContactForm(newPerson, (err) => {
                                 ~~~~~~~~~
```

Changing `(contact: Contact` to `(contact: Partial<Contact>` removes the error.
The contact is not supposed to be required to be complete right?

