### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/react-native-contacts.podspec
+++ b/react-native-contacts.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/rt2zz/react-native-contacts.git" } 
   s.source_files   = 'ios/RCTContacts/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
Xcode 12 won't build if a module depends on React instead of React-Core. 

More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116