### PR TITLE
Feature/view contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ If you'd like to read/write the contact's notes, call the `iosEnableNotesUsage(t
  * `getPhotoForId(contactId)`: Promise<string> - returns a URI (or null) for a contacts photo
  * `addContact(contact)`: Promise<Contact> - adds a contact to the AddressBook.  
  * `openContactForm(contact)` - create a new contact and display in contactsUI. 
- * `openExistingContact(contact)` - where contact is an object with a valid recordID
+ * `openExistingContact(contact)` - open existing contact (edit mode), where contact is an object with a valid recordID
+ * `viewExistingContact(contact)` - open existing contact (view mode), where contact is an object with a valid recordID
  * `editExistingContact(contact)`: Promise<Contact> - add numbers to the contact, where the contact is an object with a valid recordID and an array of phoneNumbers
  * `updateContact(contact)`: Promise<Contact> - where contact is an object with a valid recordID  
  * `deleteContact(contact)` - where contact is an object with a valid recordID  

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -519,6 +519,28 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
             promise.reject(e.toString());
         }
     }
+
+ /*
+     * View contact in native app
+     */
+    @ReactMethod
+    public void viewExistingContact(ReadableMap contact, Promise promise) {
+
+        String recordID = contact.hasKey("recordID") ? contact.getString("recordID") : null;
+
+        try {
+            Uri uri = Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_URI, recordID);
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setDataAndType(uri, ContactsContract.Contacts.CONTENT_ITEM_TYPE);
+            intent.putExtra("finishActivityOnSaveCompleted", true);
+
+            updateContactPromise = promise;
+            getReactApplicationContext().startActivityForResult(intent, REQUEST_OPEN_EXISTING_CONTACT, Bundle.EMPTY);
+
+        } catch (Exception e) {
+            promise.reject(e.toString());
+        }
+    }
     
     /*
      * Edit contact in native app

--- a/example/App.js
+++ b/example/App.js
@@ -186,6 +186,7 @@ export default class App extends Component<Props> {
                       title={`${contact.givenName} ${contact.familyName}`}
                       description={`${contact.company}`}
                       onPress={() => this.onPressContact(contact)}
+                      onLongPress={() => Contacts.viewExistingContact(contact)}
                       onDelete={() =>
                         Contacts.deleteContact(contact).then(() => {
                           this.loadContacts();


### PR DESCRIPTION
This PR adds a new method (for both iOS and Android) which allows users to open an existing contact **not** in edit mode.

This method is new, so there are no expected changes in behaviour on either platform. I have modified the example app to invoke this method upon a "long press" of one of the contacts.

**An initial test plan for this feature:**

1. Install the example app on a simulator
2. Long-press one of the contact rows

Expected behaviour: The contact is opened, but the contact details are shown **not** in edit mode.

Here is a gif of the iOS simulator, showing the current `onPress` behaviour, followed by the new "View" behaviour
![Simulator Screen Recording - iPhone 12 - 2021-10-28 at 19 21 01](https://user-images.githubusercontent.com/2563474/139313146-b2f81715-049c-4700-94e6-368acda63287.gif)