### PR TITLE
iOS Dark mode contact card header buttons and text invisible

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -676,18 +676,8 @@ RCT_EXPORT_METHOD(openContactForm:(NSDictionary *)contactData
                 viewController = viewController.presentedViewController;
             }
         [viewController presentViewController:navigation animated:YES completion:nil];
-        
-        if (@available(iOS 13, *)) {
-            viewController.view.window.backgroundColor=[UIColor blackColor];
-            navigation.navigationBar.topItem.title = @"";
-            UIView *statusBar = [[UIView alloc]initWithFrame:[UIApplication sharedApplication].keyWindow.windowScene.statusBarManager.statusBarFrame];
-            statusBar.backgroundColor = [UIColor blackColor];
-            statusBar.tag=1;
-            controller.navigationController.navigationBar.tintColor = [UIColor blackColor];
-            [[UIApplication sharedApplication].keyWindow addSubview:statusBar];
-        }
 
-        updateContactPromise = resolve;
+        self->updateContactPromise = resolve;
     });
 }
 
@@ -860,17 +850,7 @@ RCT_EXPORT_METHOD(editExistingContact:(NSDictionary *)contactData resolver:(RCTP
             [viewController presentViewController:navigation animated:YES completion:nil];
             [controller presentViewController:alert animated:YES completion:nil];
 
-            if (@available(iOS 13, *)) {
-                viewController.view.window.backgroundColor=[UIColor blackColor];
-                navigation.navigationBar.topItem.title = @"";
-                UIView *statusBar = [[UIView alloc]initWithFrame:[UIApplication sharedApplication].keyWindow.windowScene.statusBarManager.statusBarFrame];
-                statusBar.backgroundColor = [UIColor blackColor];
-                statusBar.tag=1;
-                controller.navigationController.navigationBar.tintColor = [UIColor blackColor];
-                [[UIApplication sharedApplication].keyWindow addSubview:statusBar];
-            }
-
-            updateContactPromise = resolve;
+            self->updateContactPromise = resolve;
         });
         
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -924,12 +904,6 @@ RCT_EXPORT_METHOD(editExistingContact:(NSDictionary *)contactData resolver:(RCTP
         }
 
         updateContactPromise = nil;
-    }
-    
-    UIView *statusBar = [[UIApplication sharedApplication].keyWindow viewWithTag:1];
-    
-    if(statusBar) {
-        [statusBar removeFromSuperview];
     }
 }
 


### PR DESCRIPTION
This PR is to fix #639 which causes the contact sheet's header buttons and text to be invisible when using dark mode.

It also fixes the problem with the statusBar colour which causes you app's custom statusBar colour to be replaced (This is only noticeable if the phone has a notch)

I have tested this on iOS13.0 (Simulator), 14.7.1 (iPhone 8+) and 15.1 (iPhone X) and it behaves as expected: when in dark mode, the header buttons use the accent colour and the title is white.

The problem:

https://user-images.githubusercontent.com/5883791/140702296-10e7b06a-2062-4484-be6f-8a24654ea225.mov

The fix:

https://user-images.githubusercontent.com/5883791/140702910-1603da10-653d-4ac7-bbd7-629b0df8c87e.mov



