### PR TITLE
Update RCTContacts.m to use correct UIBarButtonItemStyle constant

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -706,7 +706,7 @@ RCT_EXPORT_METHOD(openExistingContact:(NSDictionary *)contactData resolver:(RCTP
         CNContactViewController *contactViewController = [CNContactViewController viewControllerForContact:contact];
 
         // Add a cancel button which will close the view
-        contactViewController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:backTitle == nil ? @"Cancel" : backTitle style:UIBarButtonSystemItemCancel target:self action:@selector(cancelContactForm)];
+        contactViewController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:backTitle == nil ? @"Cancel" : backTitle style:UIBarButtonItemStyleDone target:self action:@selector(cancelContactForm)];
         contactViewController.delegate = self;
 
 


### PR DESCRIPTION
`openExistingContact:...` was creating a `UIBarButtonItem` with a `style` of `UIBarButtonSystemItemCancel`.  However `UIBarButtonSystemItemCancel` is not a style, it is a type of item.  Instead we should use `UIBarButtonItemStyleDone`

This will avoid raising a `-Wenum-conversion` error and fixes the bug for the style ending up being the deprecated `UIBarButtonItemStyleBordered` (`0x1`) by accident.

You can verify by enabling `-Wenum-conversion` and `-Werror=enum-conversion` in your compilation.  The current state of the code will fail with a compiler error for using the wrong enum value.  Building with this change will succeed without issue.