### PR TITLE
Update getContactById since it can return a contact or null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export function getAll(): Promise<Contact[]>;
 export function getAllWithoutPhotos(): Promise<Contact[]>;
-export function getContactById(contactId: string): Promise<Contact>;
+export function getContactById(contactId: string): Promise<Contact | null>;
 export function getCount(): Promise<number>;
 export function getPhotoForId(contactId: string): Promise<string>;
 export function addContact(contact: Partial<Contact>): Promise<Contact>;


### PR DESCRIPTION
`getContactById` can be a contact or null, so the API definition should be like below

```
getContactById(contactId: string): Promise<Contact | null>;
```

It also reflects the documentation about contact being null when does not exists

> getContactById(contactId): Promise - returns contact with defined contactId (or null if it doesn't exist)