### PR TITLE
fix: Use checkSelfPermission instead of checkCallingSelfPermission for security

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -1218,7 +1218,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
      */
     private String isPermissionGranted() {
         // return -1 for denied and 1
-        int res = getReactApplicationContext().checkCallingOrSelfPermission(PERMISSION_READ_CONTACTS);
+        int res = getReactApplicationContext().checkSelfPermission(PERMISSION_READ_CONTACTS);
         return (res == PackageManager.PERMISSION_GRANTED) ? PERMISSION_AUTHORIZED : PERMISSION_DENIED;
     }
 


### PR DESCRIPTION
- No functional change.
- Use checkSelfPermission instead of checkCallingSelfPermission for security.
- This is done to protect against accidentally leaking permissions.