### PR TITLE
support for custom user defined contact labels

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -27,6 +27,7 @@ import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
 import static android.provider.ContactsContract.CommonDataKinds.Note;
 import static android.provider.ContactsContract.CommonDataKinds.Website;
 import static android.provider.ContactsContract.CommonDataKinds.Im;
+import static android.provider.ContactsContract.CommonDataKinds.Im.getTypeLabel;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
 
 public class ContactsProvider {
@@ -390,22 +391,13 @@ public class ContactsProvider {
                     int phoneType = cursor.getInt(cursor.getColumnIndex(Phone.TYPE));
 
                     if (!TextUtils.isEmpty(phoneNumber)) {
-                        String label;
-                        switch (phoneType) {
-                            case Phone.TYPE_HOME:
-                                label = "home";
-                                break;
-                            case Phone.TYPE_WORK:
-                                label = "work";
-                                break;
-                            case Phone.TYPE_MOBILE:
-                                label = "mobile";
-                                break;
-                            case Phone.TYPE_OTHER:
-                                label = "other";
-                                break;
-                            default:
-                                label = "other";
+                        final String label;
+                        int labelIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.LABEL);
+                        if (labelIndex >= 0) {
+                            String typeLabel = cursor.getString(labelIndex);
+                            label = getTypeLabel(Resources.getSystem(), phoneType, typeLabel).toString();
+                        } else {
+                            label = "other";
                         }
                         contact.phones.add(new Contact.Item(label, phoneNumber, id));
                     }

--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsProvider.java
@@ -27,7 +27,6 @@ import static android.provider.ContactsContract.CommonDataKinds.StructuredName;
 import static android.provider.ContactsContract.CommonDataKinds.Note;
 import static android.provider.ContactsContract.CommonDataKinds.Website;
 import static android.provider.ContactsContract.CommonDataKinds.Im;
-import static android.provider.ContactsContract.CommonDataKinds.Im.getTypeLabel;
 import static android.provider.ContactsContract.CommonDataKinds.StructuredPostal;
 
 public class ContactsProvider {
@@ -395,7 +394,7 @@ public class ContactsProvider {
                         int labelIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.LABEL);
                         if (labelIndex >= 0) {
                             String typeLabel = cursor.getString(labelIndex);
-                            label = getTypeLabel(Resources.getSystem(), phoneType, typeLabel).toString();
+                            label = ContactsContract.CommonDataKinds.Phone..getTypeLabel(Resources.getSystem(), phoneType, typeLabel).toString();
                         } else {
                             label = "other";
                         }


### PR DESCRIPTION
Hello folks! I found it quite confusing that some labels change to 'other' after the contact import. I made a following change where all labels are translated into the language used in the phone. It also works with user-defined labels. 
 
![custom_labels](https://github.com/morenoh149/react-native-contacts/assets/7740573/5f6d72b5-5f0f-4f11-b33e-b79ba77316f5)
