### PR TITLE
Use ActivityCompat to check if permission is granted

### DIFF
--- a/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/main/java/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -1218,7 +1218,7 @@ public class ContactsManager extends ReactContextBaseJavaModule implements Activ
      */
     private String isPermissionGranted() {
         // return -1 for denied and 1
-        int res = getReactApplicationContext().checkSelfPermission(PERMISSION_READ_CONTACTS);
+        int res = ActivityCompat.checkSelfPermission(getReactApplicationContext(), PERMISSION_READ_CONTACTS);
         return (res == PackageManager.PERMISSION_GRANTED) ? PERMISSION_AUTHORIZED : PERMISSION_DENIED;
     }
 


### PR DESCRIPTION
There was a crash on pre-6.0 Android devices
`context.checkSelfPermission()` required API level 23

```
Caused by java.lang.NoSuchMethodError: No virtual method checkSelfPermission(Ljava/lang/String;)I in class Lcom/facebook/react/bridge/ReactApplicationContext; or its super classes
       at com.rt2zz.reactnativecontacts.ContactsManager.isPermissionGranted(ContactsManager.java:1221)
       at com.rt2zz.reactnativecontacts.ContactsManager.checkPermission(ContactsManager.java:1149)
       at java.lang.reflect.Method.invoke(Method.java)
       ...
```