### PR TITLE
Fix: solved error on ios that prevented the creation of the contacts module

### DIFF
--- a/ios/RCTContacts/RCTContacts.m
+++ b/ios/RCTContacts/RCTContacts.m
@@ -1221,9 +1221,13 @@ RCT_EXPORT_METHOD(deleteContact:(NSDictionary *)contactData resolver:(RCTPromise
     }
 }
 
-RCT_EXPORT_METHOD(writePhotoToPath:(RCTResponseSenderBlock) rejecter:(RCTPromiseRejectBlock) reject)
+RCT_EXPORT_METHOD(writePhotoToPath:(nonnull NSString *)path resolver:(RCTPromiseResolveBlock) resolve rejecter:(RCTPromiseRejectBlock) reject)
 { 
-    reject(@"Error", @"not implemented", nil);
+    @try {
+        //Nothing is implemented here
+    } @catch (NSException *exception) {
+        reject(@"Error", @"not implemented", nil);
+    }
 }
 
 -(CNContactStore*) contactsStore: (RCTPromiseRejectBlock) reject {


### PR DESCRIPTION
Fixed this error

[See attached]

![rn-contacts-error](https://github.com/user-attachments/assets/710b77a6-2663-434b-878f-1f292f957803)
