### PR TITLE
revert `package.json` to get types from `index.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/rt2zz/react-native-contacts",
   "main": "index.ts",
-  "types": "index.ts",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
since the last pr of migrating `new_arch`
now to import types we have to get it from type.is
and to import the functions we have to get it from index.d.ts
```
import Contact  from 'react-native-contacts';

import { Contact } from 'react-native-contacts/type';
```
I believe since we already have an index.d.ts 
we don't need an extra path here and import everything from one file
so it will look like this 
```
 import Contact, {Contact,UrlAddress}  from 'react-native-contacts';
 ```

