### PR TITLE
feat: add group functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ If you'd like to read/write the contact's notes, call the `iosEnableNotesUsage(t
  * `requestPermission()`: Promise<string> - request permission to access Contacts _ios only_
  * `writePhotoToPath()` - writes the contact photo to a given path _android only_
 
+ ### ios group specific functions
+ * `getGroups()`: Promise - returns an array of all groups. Each group contains `{ identifier: string; name: string;}`
+ * `getGroup: (identifier: string)`: Promise - returns the group matching the provided group identifier.
+ * `deleteGroup(identifier: string)`: Promise - deletes a group by group identifier.
+ * `updateGroup(identifier: string, groupData: Pick<Group, 'name'>`: Promise - updates an existing group's details. You can only change the group name.
+ * `addGroup(group: Pick<Group, 'name'>)`: Promise - adds a new group. Group name should be provided.
+ * `contactsInGroup(identifier: string)`: Promise - retrieves all contacts within a specified group.
+ * `addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[])`: Promise - adds contacts to a group. Only contacts with id that has `:ABperson` as suffix can be added.
+ * `removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[])`: Promise - removes specified contacts from a group.
+
 ## Example Contact Record
 ```js
 {

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,8 +24,8 @@ export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
 export function addGroup(group: Partial<Group>): Promise<Group>;
 export function contactsInGroup(identifier: string): Promise<Contact[]>; 
-export function addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
-export function removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
+export function addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
+export function removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
 export function addGroup(group: Partial<Group>): Promise<Group>;
+export function contactsInGroup(identifier: string): Promise<Contact[]>; 
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export function writePhotoToPath(contactId: string, file: string): Promise<boole
 export function iosEnableNotesUsage(enabled: boolean): void;
 
 export function getGroups(): Promise<Group[]>;
+export function getGroup(identifier: string): Promise<Group | null>;
 
 export interface Group {
   identifier: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export function requestPermission(): Promise<'authorized' | 'denied' | 'undefine
 export function writePhotoToPath(contactId: string, file: string): Promise<boolean>;
 export function iosEnableNotesUsage(enabled: boolean): void;
 
-export function getAllGroups(): Promise<Group[]>;
+export function getGroups(): Promise<Group[]>;
 
 export interface Group {
   identifier: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
 export function addGroup(group: Partial<Group>): Promise<Group>;
 export function contactsInGroup(identifier: string): Promise<Contact[]>; 
+export function addContactsToGroup(groupId: string, contactIds: string[]): Promise<boolean>;
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
-  
+export function addGroup(group: Partial<Group>): Promise<Group>;
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export function iosEnableNotesUsage(enabled: boolean): void;
 
 export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
-
+export function deleteGroup(identifier: string): Promise<boolean>;
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string, groupData: Pick<Group, 'name'>): Promise<Group>;
-export function addGroup(group: Partial<Group>): Promise<Group>;
+export function addGroup(group: Pick<Group, 'name'>): Promise<Group>;
 export function contactsInGroup(identifier: string): Promise<Contact[]>; 
 export function addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
 export function removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,12 @@ export function requestPermission(): Promise<'authorized' | 'denied' | 'undefine
 export function writePhotoToPath(contactId: string, file: string): Promise<boolean>;
 export function iosEnableNotesUsage(enabled: boolean): void;
 
+export function getAllGroups(): Promise<Group[]>;
+
+export interface Group {
+  identifier: string;
+  name: string;
+}
 export interface EmailAddress {
     label: string;
     email: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,8 @@ export function deleteGroup(identifier: string): Promise<boolean>;
 export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
 export function addGroup(group: Partial<Group>): Promise<Group>;
 export function contactsInGroup(identifier: string): Promise<Contact[]>; 
-export function addContactsToGroup(groupId: string, contactIds: string[]): Promise<boolean>;
+export function addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
+export function removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
 export interface Group {
   identifier: string;
   name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export function iosEnableNotesUsage(enabled: boolean): void;
 export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
-export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
+export function updateGroup(identifier: string, groupData: Pick<Group, 'name'>): Promise<Group>;
 export function addGroup(group: Partial<Group>): Promise<Group>;
 export function contactsInGroup(identifier: string): Promise<Contact[]>; 
 export function addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@ export function iosEnableNotesUsage(enabled: boolean): void;
 export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
+export function updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
+  
 export interface Group {
   identifier: string;
   name: string;

--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,10 @@ async function deleteGroup(identifier: string): Promise<boolean> {
 async function updateGroup(identifier: string, groupData: Partial<Group>): Promise<Group> {
   return Contacts.updateGroup(identifier, groupData);
 }
+async function addGroup(group: Partial<Group>): Promise<Group>{
+  return Contacts.addGroup(group);
+}
+
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -122,5 +126,6 @@ export default {
   getGroups,
   getGroup,
   deleteGroup,
-  updateGroup
+  updateGroup,
+  addGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from "react-native";
 import NativeContacts from "./src/NativeContacts";
-import { Contact, PermissionType } from "./type";
+import { Contact, Group, PermissionType } from "./type";
 
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 const Contacts = isTurboModuleEnabled ? NativeContacts : NativeModules.Contacts;
@@ -87,6 +87,10 @@ async function writePhotoToPath(
 ): Promise<boolean> {
   return Contacts.writePhotoToPath(contactId, file);
 }
+
+async function getAllGroups(): Promise<Group[]> {
+  return Contacts.getAllGroups();
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -106,4 +110,5 @@ export default {
   checkPermission,
   requestPermission,
   writePhotoToPath,
+  getAllGroups
 };

--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ async function getGroup(identifier: string): Promise<Group | null> {
 async function deleteGroup(identifier: string): Promise<boolean> {
   return Contacts.deleteGroup(identifier);
 }
-async function updateGroup(identifier: string, groupData: Partial<Group>): Promise<Group> {
+async function updateGroup(identifier: string, groupData: Pick<Group, 'name'>): Promise<Group> {
   return Contacts.updateGroup(identifier, groupData);
 }
 async function addGroup(group: Partial<Group>): Promise<Group>{

--- a/index.ts
+++ b/index.ts
@@ -106,11 +106,11 @@ async function addGroup(group: Partial<Group>): Promise<Group>{
 async function contactsInGroup(identifier: string): Promise<Contact[]> {
   return Contacts.contactsInGroup(identifier);
 }
-async function addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean> {
-  return Contacts.addContactsToGroup(groupIdentifier, contactIdetifiers);
+async function addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean> {
+  return Contacts.addContactsToGroup(groupIdentifier, contactIdentifiers);
 }
-async function removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean> {
-  return Contacts.removeContactsFromGroup(groupIdentifier, contactIdetifiers);
+async function removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean> {
+  return Contacts.removeContactsFromGroup(groupIdentifier, contactIdentifiers);
 }
 export default {
   getAll,

--- a/index.ts
+++ b/index.ts
@@ -103,7 +103,9 @@ async function updateGroup(identifier: string, groupData: Partial<Group>): Promi
 async function addGroup(group: Partial<Group>): Promise<Group>{
   return Contacts.addGroup(group);
 }
-
+async function contactsInGroup(identifier: string): Promise<Contact[]> {
+  return Contacts.contactsInGroup(identifier);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -127,5 +129,6 @@ export default {
   getGroup,
   deleteGroup,
   updateGroup,
-  addGroup
+  addGroup,
+  contactsInGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,9 @@ async function writePhotoToPath(
 async function getGroups(): Promise<Group[]> {
   return Contacts.getGroups();
 }
+async function getGroup(identifier: string): Promise<Group | null> {
+  return Contacts.getGroup(identifier);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -110,5 +113,6 @@ export default {
   checkPermission,
   requestPermission,
   writePhotoToPath,
-  getGroups
+  getGroups,
+  getGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -97,6 +97,9 @@ async function getGroup(identifier: string): Promise<Group | null> {
 async function deleteGroup(identifier: string): Promise<boolean> {
   return Contacts.deleteGroup(identifier);
 }
+async function updateGroup(identifier: string, groupData: Partial<Group>): Promise<Group> {
+  return Contacts.updateGroup(identifier, groupData);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -118,5 +121,6 @@ export default {
   writePhotoToPath,
   getGroups,
   getGroup,
-  deleteGroup
+  deleteGroup,
+  updateGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -88,8 +88,8 @@ async function writePhotoToPath(
   return Contacts.writePhotoToPath(contactId, file);
 }
 
-async function getAllGroups(): Promise<Group[]> {
-  return Contacts.getAllGroups();
+async function getGroups(): Promise<Group[]> {
+  return Contacts.getGroups();
 }
 export default {
   getAll,
@@ -110,5 +110,5 @@ export default {
   checkPermission,
   requestPermission,
   writePhotoToPath,
-  getAllGroups
+  getGroups
 };

--- a/index.ts
+++ b/index.ts
@@ -100,7 +100,7 @@ async function deleteGroup(identifier: string): Promise<boolean> {
 async function updateGroup(identifier: string, groupData: Pick<Group, 'name'>): Promise<Group> {
   return Contacts.updateGroup(identifier, groupData);
 }
-async function addGroup(group: Partial<Group>): Promise<Group>{
+async function addGroup(group: Pick<Group, 'name'>): Promise<Group>{
   return Contacts.addGroup(group);
 }
 async function contactsInGroup(identifier: string): Promise<Contact[]> {

--- a/index.ts
+++ b/index.ts
@@ -94,6 +94,9 @@ async function getGroups(): Promise<Group[]> {
 async function getGroup(identifier: string): Promise<Group | null> {
   return Contacts.getGroup(identifier);
 }
+async function deleteGroup(identifier: string): Promise<boolean> {
+  return Contacts.deleteGroup(identifier);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -114,5 +117,6 @@ export default {
   requestPermission,
   writePhotoToPath,
   getGroups,
-  getGroup
+  getGroup,
+  deleteGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,9 @@ async function addGroup(group: Partial<Group>): Promise<Group>{
 async function contactsInGroup(identifier: string): Promise<Contact[]> {
   return Contacts.contactsInGroup(identifier);
 }
+async function addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean> {
+  return Contacts.addContactsToGroup(groupIdentifier, contactIdetifiers);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -130,5 +133,6 @@ export default {
   deleteGroup,
   updateGroup,
   addGroup,
-  contactsInGroup
+  contactsInGroup,
+  addContactsToGroup
 };

--- a/index.ts
+++ b/index.ts
@@ -109,6 +109,9 @@ async function contactsInGroup(identifier: string): Promise<Contact[]> {
 async function addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean> {
   return Contacts.addContactsToGroup(groupIdentifier, contactIdetifiers);
 }
+async function removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean> {
+  return Contacts.removeContactsFromGroup(groupIdentifier, contactIdetifiers);
+}
 export default {
   getAll,
   getAllWithoutPhotos,
@@ -134,5 +137,6 @@ export default {
   updateGroup,
   addGroup,
   contactsInGroup,
-  addContactsToGroup
+  addContactsToGroup,
+  removeContactsFromGroup
 };

--- a/ios/RCTContacts/RCTContacts.mm
+++ b/ios/RCTContacts/RCTContacts.mm
@@ -1258,6 +1258,33 @@ RCT_EXPORT_METHOD(writePhotoToPath:(nonnull NSString *)path resolver:(RCTPromise
     }
 }
 
+RCT_EXPORT_METHOD(getAllGroups:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+    if (!contactStore) {
+        contactStore = [[CNContactStore alloc] init];
+    }
+
+    NSError *error = nil;
+    NSArray<CNGroup *> *groups = [contactStore groupsMatchingPredicate:nil error:&error];
+
+    if (error) {
+        reject(@"get_groups_error", @"Failed to fetch groups", error);
+        return;
+    }
+
+    NSMutableArray *groupArray = [NSMutableArray array];
+    for (CNGroup *group in groups) {
+        NSDictionary *groupDict = @{
+            @"identifier": group.identifier ?: @"",
+            @"name": group.name ?: @""
+        };
+        [groupArray addObject:groupDict];
+    }
+
+    resolve(groupArray);
+}
+
+
 -(CNContactStore*) contactsStore: (RCTPromiseRejectBlock) reject {
     if(!contactStore) {
         CNContactStore* store = [[CNContactStore alloc] init];

--- a/ios/RCTContacts/RCTContacts.mm
+++ b/ios/RCTContacts/RCTContacts.mm
@@ -1258,7 +1258,7 @@ RCT_EXPORT_METHOD(writePhotoToPath:(nonnull NSString *)path resolver:(RCTPromise
     }
 }
 
-RCT_EXPORT_METHOD(getAllGroups:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(getGroups:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
     if (!contactStore) {
         contactStore = [[CNContactStore alloc] init];

--- a/ios/RCTContacts/RCTContacts.mm
+++ b/ios/RCTContacts/RCTContacts.mm
@@ -1283,7 +1283,36 @@ RCT_EXPORT_METHOD(getGroups:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRe
 
     resolve(groupArray);
 }
-
+RCT_EXPORT_METHOD(getGroup:(NSString *)identifier resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    CNContactStore *contactStore = [self contactsStore:reject];
+    if (!contactStore) {
+        // contactsStore method handles rejection
+        return;
+    }
+    
+    NSError *error = nil;
+    NSPredicate *predicate = [CNGroup predicateForGroupsWithIdentifiers:@[identifier]];
+    NSArray<CNGroup *> *groups = [contactStore groupsMatchingPredicate:predicate error:&error];
+    
+    if (error) {
+        reject(@"get_group_error", @"Failed to fetch group", error);
+        return;
+    }
+    
+    if (groups.count == 0) {
+        reject(@"get_group_not_found", @"No group found with the given identifier", nil);
+        return;
+    }
+    
+    CNGroup *group = groups.firstObject;
+    NSDictionary *groupDict = @{
+        @"identifier": group.identifier ?: @"",
+        @"name": group.name ?: @""
+    };
+    
+    resolve(groupDict);
+}
 
 -(CNContactStore*) contactsStore: (RCTPromiseRejectBlock) reject {
     if(!contactStore) {

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -27,6 +27,7 @@ export interface Spec extends TurboModule {
   deleteGroup(identifier: string): Promise<boolean>;
   updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
   addGroup(group: Partial<Group>): Promise<Group>;
+  contactsInGroup(identifier: string): Promise<Contact[]>;
 
 }
 

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -24,6 +24,7 @@ export interface Spec extends TurboModule {
   iosEnableNotesUsage: (enabled: boolean) => void;
   getGroups(): Promise<Group[]>;
   getGroup: (identifier: string) => Promise<Group | null>;
+  deleteGroup(identifier: string): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
 import { TurboModuleRegistry } from "react-native";
-import { Contact, PermissionType } from "../type";
+import { Contact, Group, PermissionType } from "../type";
 
 export interface Spec extends TurboModule {
   getAll: () => Promise<any>;
@@ -22,6 +22,7 @@ export interface Spec extends TurboModule {
   requestPermission: () => Promise<PermissionType>;
   writePhotoToPath: (contactId: string, file: string) => Promise<boolean>;
   iosEnableNotesUsage: (enabled: boolean) => void;
+  getAllGroups(): Promise<Group[]>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -28,7 +28,8 @@ export interface Spec extends TurboModule {
   updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
   addGroup(group: Partial<Group>): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
-  addContactsToGroup(groupId: string, contactIds: string[]): Promise<boolean>;
+  addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
+  removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -28,8 +28,8 @@ export interface Spec extends TurboModule {
   updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
   addGroup(group: Partial<Group>): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
-  addContactsToGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
-  removeContactsFromGroup(groupIdentifier: string, contactIdetifiers: string[]): Promise<boolean>;
+  addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
+  removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
   updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
   addGroup(group: Partial<Group>): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
-
+  addContactsToGroup(groupId: string, contactIds: string[]): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -26,7 +26,7 @@ export interface Spec extends TurboModule {
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
   updateGroup(identifier: string,groupData: Pick<Group, 'name'>): Promise<Group>;
-  addGroup(group: Partial<Group>): Promise<Group>;
+  addGroup(group: Pick<Group, 'name'>): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
   addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
   removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -26,6 +26,8 @@ export interface Spec extends TurboModule {
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
   updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
+  addGroup(group: Partial<Group>): Promise<Group>;
+
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -25,7 +25,7 @@ export interface Spec extends TurboModule {
   getGroups(): Promise<Group[]>;
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
-  updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
+  updateGroup(identifier: string,groupData: Pick<Group, 'name'>): Promise<Group>;
   addGroup(group: Partial<Group>): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
   addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -25,6 +25,7 @@ export interface Spec extends TurboModule {
   getGroups(): Promise<Group[]>;
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
+  updateGroup(identifier: string,groupData: Partial<Group>): Promise<Group>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -23,6 +23,7 @@ export interface Spec extends TurboModule {
   writePhotoToPath: (contactId: string, file: string) => Promise<boolean>;
   iosEnableNotesUsage: (enabled: boolean) => void;
   getGroups(): Promise<Group[]>;
+  getGroup: (identifier: string) => Promise<Group | null>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -22,7 +22,7 @@ export interface Spec extends TurboModule {
   requestPermission: () => Promise<PermissionType>;
   writePhotoToPath: (contactId: string, file: string) => Promise<boolean>;
   iosEnableNotesUsage: (enabled: boolean) => void;
-  getAllGroups(): Promise<Group[]>;
+  getGroups(): Promise<Group[]>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/type.ts
+++ b/type.ts
@@ -61,4 +61,9 @@ export interface Contact {
   note: string;
 }
 
+export interface Group {
+  identifier: string;
+  name: string;
+}
+
 export type PermissionType = 'authorized' | 'limited' | 'denied' | 'undefined'


### PR DESCRIPTION
This PR partially addresses [issue #747](https://github.com/morenoh149/react-native-contacts/issues/747).

### Implemented Changes
Added getGroups() function which returns an array of group objects, including identifier and name


### Request for Feedback
I would appreciate feedback from the maintainers on whether I am heading in the right direction and if I should proceed with the implementation of other functions.


### Planned Functions

Below are the additional functions I am considering implementing:

- getGroup(groupId) - Returns the group matching the provided groupId.
- contactsInGroup(groupId) - Retrieves all contacts within a specified group.
- addGroup(groupDetails) - Adds a new group.
- updateGroup(groupId, updatedDetails) - Updates an existing group's details.
- deleteGroup(groupId) - Deletes a group by groupId.
- addContactsToGroup(groupId, contactIds) - Adds contacts to a group.
- removeContactsFromGroup(groupId, contactIds) - Removes specified contacts from a group.

### Question for Maintainers

Given the number of planned functions, would you prefer that I create separate PRs for each function, or include all of them in this PR?

closes #747 

