### PR TITLE
fix undeclared identifier 'CNAuthorizationStatusLimited'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,3 @@ export interface Contact {
   urlAddresses: UrlAddress[];
   note: string | null;
 }
-
-export type GroupInput = {
-  name: string;
-};

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,91 +4,121 @@ export function getContactById(contactId: string): Promise<Contact | null>;
 export function getCount(): Promise<number>;
 export function getPhotoForId(contactId: string): Promise<string>;
 export function addContact(contact: Partial<Contact>): Promise<Contact>;
-export function openContactForm(contact: Partial<Contact>): Promise<Contact | null>;
+export function openContactForm(
+  contact: Partial<Contact>
+): Promise<Contact | null>;
 export function openExistingContact(contact: Contact): Promise<Contact>;
-export function viewExistingContact(contact: { recordID: string }): Promise<Contact | void>
+export function viewExistingContact(contact: {
+  recordID: string;
+}): Promise<Contact | void>;
 export function editExistingContact(contact: Contact): Promise<Contact>;
-export function updateContact(contact: Partial<Contact> & {recordID: string}): Promise<void>;
+export function updateContact(
+  contact: Partial<Contact> & { recordID: string }
+): Promise<void>;
 export function deleteContact(contact: Contact): Promise<void>;
 export function getContactsMatchingString(str: string): Promise<Contact[]>;
-export function getContactsByPhoneNumber(phoneNumber: string): Promise<Contact[]>;
-export function getContactsByEmailAddress(emailAddress: string): Promise<Contact[]>;
-export function checkPermission(): Promise<'authorized' | 'denied' | 'undefined'>;
-export function requestPermission(): Promise<'authorized' | 'denied' | 'undefined'>;
-export function writePhotoToPath(contactId: string, file: string): Promise<boolean>;
+export function getContactsByPhoneNumber(
+  phoneNumber: string
+): Promise<Contact[]>;
+export function getContactsByEmailAddress(
+  emailAddress: string
+): Promise<Contact[]>;
+export function checkPermission(): Promise<
+  "authorized" | "denied" | "undefined"
+>;
+export function requestPermission(): Promise<
+  "authorized" | "denied" | "undefined"
+>;
+export function writePhotoToPath(
+  contactId: string,
+  file: string
+): Promise<boolean>;
 export function iosEnableNotesUsage(enabled: boolean): void;
 
 export function getGroups(): Promise<Group[]>;
 export function getGroup(identifier: string): Promise<Group | null>;
 export function deleteGroup(identifier: string): Promise<boolean>;
-export function updateGroup(identifier: string, groupData: Pick<Group, 'name'>): Promise<Group>;
-export function addGroup(group: Pick<Group, 'name'>): Promise<Group>;
-export function contactsInGroup(identifier: string): Promise<Contact[]>; 
-export function addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
-export function removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
+export function updateGroup(
+  identifier: string,
+  groupData: Pick<Group, "name">
+): Promise<Group>;
+export function addGroup(group: Pick<Group, "name">): Promise<Group>;
+export function contactsInGroup(identifier: string): Promise<Contact[]>;
+export function addContactsToGroup(
+  groupIdentifier: string,
+  contactIdentifiers: string[]
+): Promise<boolean>;
+export function removeContactsFromGroup(
+  groupIdentifier: string,
+  contactIdentifiers: string[]
+): Promise<boolean>;
 export interface Group {
   identifier: string;
   name: string;
 }
 export interface EmailAddress {
-    label: string;
-    email: string;
+  label: string;
+  email: string;
 }
 
 export interface PhoneNumber {
-    label: string;
-    number: string;
+  label: string;
+  number: string;
 }
 
 export interface PostalAddress {
-    label: string;
-    formattedAddress: string;
-    street: string;
-    pobox: string;
-    neighborhood: string;
-    city: string;
-    region: string;
-    state: string;
-    postCode: string;
-    country: string;
+  label: string;
+  formattedAddress: string;
+  street: string;
+  pobox: string;
+  neighborhood: string;
+  city: string;
+  region: string;
+  state: string;
+  postCode: string;
+  country: string;
 }
 
 export interface InstantMessageAddress {
-    username: string;
-    service: string;
+  username: string;
+  service: string;
 }
 
 export interface Birthday {
-    day: number;
-    month: number;
-    year?: number;
+  day: number;
+  month: number;
+  year?: number;
 }
 
 export interface UrlAddress {
-    url: string;
-    label: string;
+  url: string;
+  label: string;
 }
 
 export interface Contact {
-    recordID: string;
-    backTitle: string;
-    company: string|null;
-    emailAddresses: EmailAddress[];
-    displayName: string|null;
-    familyName: string;
-    givenName: string|null;
-    middleName: string;
-    jobTitle: string|null;
-    phoneNumbers: PhoneNumber[];
-    hasThumbnail: boolean;
-    thumbnailPath: string;
-    isStarred: boolean;
-    postalAddresses: PostalAddress[];
-    prefix: string|null;
-    suffix: string|null;
-    department: string|null;
-    birthday?: Birthday;
-    imAddresses: InstantMessageAddress[];
-    urlAddresses: UrlAddress[];
-    note: string|null;
+  recordID: string;
+  backTitle: string;
+  company: string | null;
+  emailAddresses: EmailAddress[];
+  displayName: string | null;
+  familyName: string;
+  givenName: string | null;
+  middleName: string;
+  jobTitle: string | null;
+  phoneNumbers: PhoneNumber[];
+  hasThumbnail: boolean;
+  thumbnailPath: string;
+  isStarred: boolean;
+  postalAddresses: PostalAddress[];
+  prefix: string | null;
+  suffix: string | null;
+  department: string | null;
+  birthday?: Birthday;
+  imAddresses: InstantMessageAddress[];
+  urlAddresses: UrlAddress[];
+  note: string | null;
 }
+
+export type GroupInput = {
+  name: string;
+};

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
 import { TurboModuleRegistry } from "react-native";
-import { Contact, Group, GroupInput, PermissionType } from "../type";
+import { Contact, Group, PermissionType } from "../type";
 
 export interface Spec extends TurboModule {
   getAll: () => Promise<any>;
@@ -25,7 +25,7 @@ export interface Spec extends TurboModule {
   getGroups(): Promise<Group[]>;
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
-  updateGroup(identifier: string, groupData: GroupInput): Promise<Group>;
+  updateGroup(identifier: string, groupData: Object): Promise<Group>;
   addGroup(group: Pick<Group, "name">): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
   addContactsToGroup(

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -26,7 +26,7 @@ export interface Spec extends TurboModule {
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
   updateGroup(identifier: string, groupData: Object): Promise<Group>;
-  addGroup(group: Pick<Group, "name">): Promise<Group>;
+  addGroup(group: Object): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
   addContactsToGroup(
     groupIdentifier: string,

--- a/src/NativeContacts.ts
+++ b/src/NativeContacts.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
 import { TurboModuleRegistry } from "react-native";
-import { Contact, Group, PermissionType } from "../type";
+import { Contact, Group, GroupInput, PermissionType } from "../type";
 
 export interface Spec extends TurboModule {
   getAll: () => Promise<any>;
@@ -25,11 +25,17 @@ export interface Spec extends TurboModule {
   getGroups(): Promise<Group[]>;
   getGroup: (identifier: string) => Promise<Group | null>;
   deleteGroup(identifier: string): Promise<boolean>;
-  updateGroup(identifier: string,groupData: Pick<Group, 'name'>): Promise<Group>;
-  addGroup(group: Pick<Group, 'name'>): Promise<Group>;
+  updateGroup(identifier: string, groupData: GroupInput): Promise<Group>;
+  addGroup(group: Pick<Group, "name">): Promise<Group>;
   contactsInGroup(identifier: string): Promise<Contact[]>;
-  addContactsToGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
-  removeContactsFromGroup(groupIdentifier: string, contactIdentifiers: string[]): Promise<boolean>;
+  addContactsToGroup(
+    groupIdentifier: string,
+    contactIdentifiers: string[]
+  ): Promise<boolean>;
+  removeContactsFromGroup(
+    groupIdentifier: string,
+    contactIdentifiers: string[]
+  ): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>("RCTContacts");

--- a/type.ts
+++ b/type.ts
@@ -65,8 +65,5 @@ export interface Group {
   identifier: string;
   name: string;
 }
-export interface GroupInput {
-  name: string;
-}
 
 export type PermissionType = "authorized" | "limited" | "denied" | "undefined";

--- a/type.ts
+++ b/type.ts
@@ -65,5 +65,8 @@ export interface Group {
   identifier: string;
   name: string;
 }
+export interface GroupInput {
+  name: string;
+}
 
-export type PermissionType = 'authorized' | 'limited' | 'denied' | 'undefined'
+export type PermissionType = "authorized" | "limited" | "denied" | "undefined";


### PR DESCRIPTION
hello 
in this pr fixes #758
also, there was an interesting case here
`addGroup(group: Pick<Group, "name">): Promise<Group>;`
`updateGroup(identifier: string,groupData: Pick<Group, 'name'>): Promise<Group>;`
while I was trying to test the lib with the latest rn `0.76.3` I got this error 
`UnsupportedGenericParserError: Module NativeContacts: Unrecognized generic type 'Pick' in NativeModule spec.`
and there is an [issue](https://github.com/facebook/react-native/issues/38769) already opened in react-native 
so I removed Pick and replaced it with just type
