### PR TITLE
Fix: React Native 0.77.1 Compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,7 @@ import { NativeModules } from "react-native";
 import NativeContacts from "./src/NativeContacts";
 import { Contact, Group, PermissionType } from "./type";
 
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-const Contacts = isTurboModuleEnabled ? NativeContacts : NativeModules.Contacts;
+const Contacts = NativeModules.Contacts ?? NativeContacts;
 
 async function getAll(): Promise<Contact[]> {
   return Contacts.getAll();


### PR DESCRIPTION
This pull request addresses compatibility issues with React Native 0.77.1 by updating the assignment of the `Contacts` module. The previous implementation utilized `global.__turboModuleProxy`, which has been deprecated in favor of direct TurboModule access via `NativeModules`.

**Changes:**
- Removed reliance on `global.__turboModuleProxy`.
- Updated `Contacts` assignment to use `NativeModules.Contacts ?? NativeContacts`.

In React Native 0.77.1, the `global.__turboModuleProxy` has been deprecated, and direct access to TurboModules through `NativeModules` is now the recommended approach. This change ensures that the `Contacts` module is correctly assigned, maintaining functionality across versions.

**References:**
- [React Native 0.77.0-rc.0 Release Notes](https://www.gitclear.com/open_repos/facebook/react-native/release/v0.77.0-rc.0)
- [React Native 0.77 Blog Post](https://reactnative.dev/blog/2025/01/21/version-0.77)

@morenoh149 