### PR TITLE
chore: add version files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,7 @@ ios/RCTContacts.xcodeproj/project.xcworkspace
 .npm-debug.log
 
 example/
+
+# version files
+.tool-versions
+.nvmrc


### PR DESCRIPTION
👋 Hello folks,

I guess the GitHub action is outdated now and you've been publishing the package locally.

One issue is `.tool-versions` files are detected by tools like https://asdf-vm.com/ and causing issues if the host machine does not have the exact `npmjs` installed.

The only way to make it work is to delete the `.tool-versions` file after every install.
 