### PR TITLE
fix: make sure react-native-contacts work with prebuilds

### DIFF
--- a/react-native-contacts.podspec
+++ b/react-native-contacts.podspec
@@ -19,20 +19,6 @@ Pod::Spec.new do |s|
   s.source_files   = "ios/**/*.{h,m,mm,swift}"
   s.frameworks     = 'Contacts', 'ContactsUI', 'Photos'
 
-  s.dependency 'React-Core'
+  install_modules_dependencies(s)
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-    install_modules_dependencies(s)
-  end
 end


### PR DESCRIPTION
The `install_modules_dependencies` function is a utility function provided by React Native to configure all the react-native's  related dependencies.
It also sets headers search paths and cpluplus flags and it handles legacy/new arch swith as well.

In that function, we also backed all the changes required by the libraries to properly work with prebuilds.

You can use only this function to explicit all the dependencies for React Native contacts.

## Test Plan

```
npx @react-native-community/cli init Nex --version next --skip-install # creates an app with 0.81
cd Next
yarn add react-native-contacts
cd ios
bundle install
RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 bundle exec pod install
# Observe the pod install step fail for wrongly set dependencies

# Modify the podspec with the change in this PR
RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 bundle exec pod install
open Next.xcworkspace
# build in Xcode
```

<img width="1294" height="627" alt="Screenshot 2025-07-28 at 15 48 40" src="https://github.com/user-attachments/assets/9313072f-f16f-42ec-8310-0f5e069eae12" />