### PR TITLE
 Fix: Add missing group method implementations for Android New Archit…

### DIFF
--- a/android/src/newarch/com/rt2zz/reactnativecontacts/ContactsManager.java
+++ b/android/src/newarch/com/rt2zz/reactnativecontacts/ContactsManager.java
@@ -10,6 +10,7 @@ import android.graphics.BitmapFactory;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.rt2zz.reactnativecontacts.impl.ContactsManagerImpl;
 
@@ -220,6 +221,46 @@ public class ContactsManager extends NativeContactsSpec implements ActivityEvent
     @Override
     public void iosEnableNotesUsage(boolean enabled) {
         // this method is only needed for iOS
+    }
+
+    @Override
+    public void getGroups(Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void getGroup(String identifier, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void deleteGroup(String identifier, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void updateGroup(String identifier, ReadableMap groupData, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void addGroup(ReadableMap group, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void contactsInGroup(String identifier, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void addContactsToGroup(String groupIdentifier, ReadableArray contactIdentifiers, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
+    }
+
+    @Override
+    public void removeContactsFromGroup(String groupIdentifier, ReadableArray contactIdentifiers, Promise promise) {
+        promise.reject("NOT_IMPLEMENTED", "Groups functionality not implemented on Android");
     }
 
 


### PR DESCRIPTION
The ContactsManager class in the new architecture (newarch) was missing 8 abstract method implementations required by NativeContactsSpec, causing compilation
  failures:

  ContactsManager is not abstract and does not override abstract method removeContactsFromGroup(String,ReadableArray,Promise) in NativeContactsSpec

  Root Cause

  The NativeContactsSpec interface (generated by React Native's codegen) defines 8 group-related abstract methods that must be implemented:
  - getGroups
  - getGroup
  - deleteGroup
  - updateGroup
  - addGroup
  - contactsInGroup
  - addContactsToGroup
  - removeContactsFromGroup

  However, the Android implementation in ContactsManager.java was missing these methods, while the underlying ContactsManagerImpl doesn't have group
  functionality implemented.

  Solution

  1. Added missing import: ReadableArray for method parameters
  2. Implemented 8 missing methods with proper stub implementations that reject with "NOT_IMPLEMENTED" error messages, since group functionality appears to be
  iOS-specific

  Changes

  - File: android/src/newarch/com/rt2zz/reactnativecontacts/ContactsManager.java
  - Added: import com.facebook.react.bridge.ReadableArray;
  - Added: 8 method implementations that reject with informative error messages

  Testing

  - ✅ Android build compiles successfully
  - ✅ Methods reject appropriately when called
  - ✅ No impact on existing functionality
  - ✅ Maintains API contract compatibility

  This fix ensures the library works with React Native's new architecture while providing clear feedback about unsupported group features on Android.

